### PR TITLE
Drop libusb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/org.openhantek.OpenHantek6022.yml
+++ b/org.openhantek.OpenHantek6022.yml
@@ -15,18 +15,10 @@ rename-desktop-file: org.openhantek.OpenHantek.desktop
 rename-icon: OpenHantek
 
 modules:
-  - shared-modules/libusb/libusb.json
-
-  - name: appdata
-    buildsystem: simple
-    build-commands:
-      - install -Dt $FLATPAK_DEST/share/metainfo/ org.openhantek.OpenHantek6022.metainfo.xml
-    sources:
-      - type: file
-        path: org.openhantek.OpenHantek6022.metainfo.xml
-
   - name: openhantek
     buildsystem: cmake
+    post-install:
+      - install -Dt $FLATPAK_DEST/share/metainfo/ org.openhantek.OpenHantek6022.metainfo.xml
     sources:
       - type: git
         url: https://github.com/OpenHantek/OpenHantek6022
@@ -35,3 +27,5 @@ modules:
         x-checker-data:
           type: git
           tag-pattern: ^([\d.]+)$
+      - type: file
+        path: org.openhantek.OpenHantek6022.metainfo.xml


### PR DESCRIPTION
Remove libusb since it's included in the runtime 5.15-25.08

Fixes: https://github.com/flathub/org.openhantek.OpenHantek6022/issues/48

PS: You can also drop shared-modules since there are no more related modules.