### PR TITLE
Drop share/docs

### DIFF
--- a/org.openhantek.OpenHantek6022.yml
+++ b/org.openhantek.OpenHantek6022.yml
@@ -13,6 +13,8 @@ finish-args:
   - --filesystem=xdg-documents
 rename-desktop-file: org.openhantek.OpenHantek.desktop
 rename-icon: OpenHantek
+cleanup:
+  - /share/doc
 
 modules:
   - shared-modules/libusb/libusb.json


### PR DESCRIPTION
They are inside the Flatpak and user can't interact with them.